### PR TITLE
ExportedCuckooFilter with serde_bytes for efficiency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ byteorder = "1.2"
 rand = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
+serde_bytes = "0.11"
 clippy = {version = "0.0.77", optional = true}
 fnv = {version = "1.0.2", optional = true}
 farmhash = {version = "1.1", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,7 @@ where
 /// A minimal representation of the CuckooFilter which can be transfered or stored, then recovered at a later stage.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ExportedCuckooFilter {
+    #[serde(with = "serde_bytes")]
     pub values: Vec<u8>,
     pub length: usize,
 }


### PR DESCRIPTION
Currently, the serialized import and export of a `CuckooFilter` is a direct copy of `ExportedCuckooFilter` struct, which is generic, portable and very human-readable aka verbose.

Unfortunately, this also means that 256 `u8` values serialized to cbor (or any other output) easily double in number of bytes used. To efficiently store or transfer an exported CuckooFilter `serde_bytes` (https://github.com/serde-rs/bytes) really shrinks the amount of data generated. This way, *n* `u8` values only take up *n* bytes (encoded as a byte buffer, not an array).

This feature  would add another dependency (even though, it is a tiny one, which itself only depends on `serde`) and maybe there are other situations where a more verbose serialization might be more useful. Even though, the only use-case I currently see where I might want to look at an `u8` array rather than a compact byte buffer is with `serde_json` and a wasm app, but even in a web context I might prefer fewer bytes to transfer as well. Nevertheless, having the exported filter in a compact form is super convenient and much more efficient.