### PR TITLE
Move Serde functionality behind a feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Serde support is now behind the feature flag `serde_support` and is disabled by default.
+
 ## [v0.4.0] - 2018-04-1
 ### Added
 - `ExportedCuckooFilter` adds the ability to serialize the memory map of a `CuckooFilter` via Serde; reducing communication overhead between nodes for example, or the ability to store the current state on disk for retrieval at a later time.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,13 +35,14 @@ edition = "2018"
 [features]
 default = []
 dev = ["clippy"]
+serde_support = ["serde", "serde_derive", "serde_bytes"]
 
 [dependencies]
 byteorder = "1.3.4"
 rand = "0.7.3"
-serde = "1.0.114"
-serde_derive = "1.0.114"
-serde_bytes = "0.11.5"
+serde = {version = "1.0.114", optional = true}
+serde_derive = {version = "1.0.114", optional = true}
+serde_bytes = {version = "0.11.5", optional = true}
 clippy = {version = "0.0.302", optional = true}
 fnv = "1.0.7"
 farmhash = {version = "1.1.5", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ use std::marker::PhantomData;
 use std::mem;
 
 use rand::Rng;
+#[cfg(feature = "serde_support")]
 use serde_derive::{Deserialize, Serialize};
 
 /// If insertion fails, we will retry this many times.
@@ -266,9 +267,10 @@ where
 }
 
 /// A minimal representation of the CuckooFilter which can be transfered or stored, then recovered at a later stage.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
 pub struct ExportedCuckooFilter {
-    #[serde(with = "serde_bytes")]
+    #[cfg_attr(feature = "serde_support", serde(with = "serde_bytes"))]
     pub values: Vec<u8>,
     pub length: usize,
 }

--- a/tests/interop.rs
+++ b/tests/interop.rs
@@ -40,6 +40,7 @@ fn interoperability() {
 }
 
 #[test]
+#[cfg(feature = "serde_support")]
 fn serialization() {
     // Just a small filter to test serialization.
     let mut filter = CuckooFilter::<DefaultHasher>::with_capacity(100);


### PR DESCRIPTION
This PR moves Serde functionality behind the feature flag `serde_support`. Note, this PR is a breaking change for anyone already using Serde functionality in this crate.

Closes #42 

## Still needed

1. run CI tests with both configurations? This could help prevent silently Serde functionally in future PRs.
