### PR TITLE
Remove dev flag for clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ edition = "2018"
 
 [features]
 default = []
-dev = ["clippy"]
 serde_support = ["serde", "serde_derive", "serde_bytes"]
 
 [dependencies]
@@ -43,7 +42,6 @@ rand = "0.7.3"
 serde = {version = "1.0.114", optional = true}
 serde_derive = {version = "1.0.114", optional = true}
 serde_bytes = {version = "0.11.5", optional = true}
-clippy = {version = "0.0.302", optional = true}
 fnv = "1.0.7"
 farmhash = {version = "1.1.5", optional = true}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,6 @@
 //! extern crate cuckoofilter;
 //! ```
 
-#![cfg_attr(feature = "dev", feature(plugin))]
-#![cfg_attr(feature = "dev", plugin(clippy))]
-
 mod bucket;
 mod util;
 


### PR DESCRIPTION
Following up on #50. This removes the dev feature flag since installing `clippy` through crates.io is deprecated.