### PR TITLE
Add clear method

### DIFF
--- a/benches/bench_lib.rs
+++ b/benches/bench_lib.rs
@@ -52,6 +52,15 @@ fn bench_new(b: &mut test::Bencher) {
     });
 }
 
+#[bench]
+fn bench_clear(b: &mut test::Bencher) {
+    let mut cf = test::black_box(CuckooFilter::new());
+
+    b.iter(|| {
+        test::black_box(cf.clear());
+    });
+}
+
 #[cfg(feature = "farmhash")]
 #[bench]
 fn bench_insertion_farmhash(b: &mut test::Bencher) {

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -89,6 +89,12 @@ impl Bucket {
             .cloned()
             .collect()
     }
+
+    /// Empties the bucket by setting each used entry to Fingerprint::empty(). Returns the number of entries that were modified.
+    #[inline(always)]
+    pub fn clear(&mut self) {
+        *self = Self::new()
+    }
 }
 
 impl From<&[u8]> for Bucket {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,16 @@ impl StdError for CuckooError {
 /// assert_eq!(cf.len(), 0);
 /// assert!(cf.is_empty());
 ///
+/// for s in &words {
+///     if cf.test_and_add(s).unwrap() {
+///         insertions += 1;
+///     }
+/// }
+///
+/// cf.clear();
+///
+/// assert!(cf.is_empty());
+///
 /// ```
 pub struct CuckooFilter<H> {
     buckets: Box<[Bucket]>,
@@ -225,6 +235,18 @@ where
     pub fn delete<T: ?Sized + Hash>(&mut self, data: &T) -> bool {
         let FaI { fp, i1, i2 } = get_fai::<T, H>(data);
         self.remove(fp, i1) || self.remove(fp, i2)
+    }
+
+    /// Empty all the buckets in a filter and reset the number of items.
+    pub fn clear(&mut self) {
+        if self.is_empty() {
+            return;
+        }
+
+        for bucket in self.buckets.iter_mut() {
+            bucket.clear();
+        }
+        self.len = 0;
     }
 
     /// Extracts fingerprint values from all buckets, used for exporting the filters data.


### PR DESCRIPTION
Resolves #33 

Add a clear method to the cuckoo filter which empties the buckets and does not require allocating new memory.