### PR TITLE
Removing Error::description and Adding Debug Derivations

### DIFF
--- a/benches/bench_lib.rs
+++ b/benches/bench_lib.rs
@@ -9,7 +9,6 @@ extern crate rand;
 extern crate test;
 
 use self::cuckoofilter::*;
-use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
@@ -22,13 +21,13 @@ fn get_words() -> String {
     let mut file = match File::open(&path) {
         // The `description` method of `io::Error` returns a string that
         // describes the error
-        Err(why) => panic!("couldn't open {}: {}", display, Error::description(&why)),
+        Err(why) => panic!("couldn't open {}: {}", display, why),
         Ok(file) => file,
     };
 
     let mut contents = String::new();
     if let Err(why) = file.read_to_string(&mut contents) {
-        panic!("couldn't read {}: {}", display, Error::description(&why));
+        panic!("couldn't read {}: {}", display, why);
     }
     contents
 }

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -3,7 +3,7 @@ pub const BUCKET_SIZE: usize = 4;
 const EMPTY_FINGERPRINT_DATA: [u8; FINGERPRINT_SIZE] = [100; FINGERPRINT_SIZE];
 
 // Fingerprint Size is 1 byte so lets remove the Vec
-#[derive(PartialEq, Copy, Clone, Hash)]
+#[derive(PartialEq, Copy, Clone, Hash, Debug)]
 pub struct Fingerprint {
     pub data: [u8; FINGERPRINT_SIZE],
 }
@@ -40,7 +40,7 @@ impl Fingerprint {
 }
 
 /// Manages `BUCKET_SIZE` fingerprints at most.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Bucket {
     pub buffer: [Fingerprint; BUCKET_SIZE],
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ where
 }
 
 /// A minimal representation of the CuckooFilter which can be transfered or stored, then recovered at a later stage.
-#[derive(Debug)]
+#[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde_support", derive(Deserialize, Serialize))]
 pub struct ExportedCuckooFilter {
     #[cfg_attr(feature = "serde_support", serde(with = "serde_bytes"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ impl StdError for CuckooError {
 /// assert!(cf.is_empty());
 ///
 /// ```
+#[derive(Debug, Clone)]
 pub struct CuckooFilter<H> {
     buckets: Box<[Bucket]>,
     len: usize,


### PR DESCRIPTION
This PR just updates the formatting of the error panics and adds `Debug` and `Clone` derivations to a few structures to enable easier debugging and handling