### PR TITLE
Rust 2021 update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ keywords = ["bloomfilter", "cuckoohashing", "cuckoofilter"]
 # be separated with a `/`
 license = "MIT"
 
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []
@@ -38,7 +38,7 @@ serde_support = ["serde", "serde_derive", "serde_bytes"]
 
 [dependencies]
 byteorder = "1.3.4"
-rand = "0.7.3"
+rand = "0.8"
 serde = {version = "1.0.114", optional = true}
 serde_derive = {version = "1.0.114", optional = true}
 serde_bytes = {version = "0.11.5", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ where
         for _ in 0..MAX_REBUCKET {
             let other_fp;
             {
-                let loc = &mut self.buckets[i % len].buffer[rng.gen_range(0, BUCKET_SIZE)];
+                let loc = &mut self.buckets[i % len].buffer[rng.gen_range(0..BUCKET_SIZE)];
                 other_fp = *loc;
                 *loc = fp;
                 i = get_alt_index::<H>(other_fp, i);


### PR DESCRIPTION
Updates the library for Rust 2021 edition and version bumps the rand library. Solves compilations to the `x86_64-unknown-linux-musl` target.